### PR TITLE
copy opencv_modules.hpp

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -49,6 +49,7 @@ conan_basic_setup()""")
 
     def package(self):
         self.copy("*.h*", "include", "opencv-%s/include" % self.version)
+        self.copy("*.h*","include/opencv2","opencv2") #opencv2/opencv_modules.hpp is generated
         for lib in self.opencv_libs:
             self.copy("*.h*", "include", "opencv-%s/modules/%s/include" % (self.version, lib))
         self.copy("*.lib", "lib", "lib", keep_path=False)


### PR DESCRIPTION
Added opencv_modules.hpp which is not in the opencv include dir as it is generated during build. Not sure if this works on windows, only tested on ubuntu. But I still can't compile the test on ubuntu 14.04 and gcc 4.8. I will have a look at it later :)
```
OpenCV/2.4.13@memsharded/testing: Package 'de9c231f84c85def9df09875e1785a1319fa8cb6' built
OpenCV/2.4.13@memsharded/testing: Build folder /home/phibedy/.conan/data/OpenCV/2.4.13/memsharded/testing/build/de9c231f84c85def9df09875e1785a1319fa8cb6
OpenCV/2.4.13@memsharded/testing: Generated conaninfo.txt
OpenCV/2.4.13@memsharded/testing: Generated conanbuildinfo.txt
OpenCV/2.4.13@memsharded/testing: Generating the package
OpenCV/2.4.13@memsharded/testing: Package folder /home/phibedy/.conan/data/OpenCV/2.4.13/memsharded/testing/package/de9c231f84c85def9df09875e1785a1319fa8cb6
OpenCV/2.4.13@memsharded/testing package(): Copied 49 '.h' files
OpenCV/2.4.13@memsharded/testing package(): Copied 1 '.so' files: cv2.so
OpenCV/2.4.13@memsharded/testing package(): Copied 38 '.a' files
OpenCV/2.4.13@memsharded/testing package(): Copied 1 '.pc' files: opencv.pc
OpenCV/2.4.13@memsharded/testing package(): Copied 134 '.hpp' files
OpenCV/2.4.13@memsharded/testing package(): Copied 44 '.xml' files
OpenCV/2.4.13@memsharded/testing: Package 'de9c231f84c85def9df09875e1785a1319fa8cb6' created
PROJECT: Generated cmake created conanbuildinfo.cmake
PROJECT: Generated conaninfo.txt
PROJECT imports(): Copied 39 '.xml' files
-- The C compiler identification is GNU 4.8.4
-- The CXX compiler identification is GNU 4.8.4
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Conan C++ stdlib: libstdc++
-- Configuring done
-- Generating done
-- Build files have been written to: /home/phibedy/Documents/programming/c++/lms_conan/config_zebrastreifen/build/tmp/conan-opencv/test_package/build/da39a3ee5e6b4b0d3255bfef95601890afd80709
Scanning dependencies of target lena
[100%] Building CXX object CMakeFiles/lena.dir/lena.cpp.o
Linking CXX executable bin/lena
/usr/bin/ld: /home/phibedy/.conan/data/OpenCV/2.4.13/memsharded/testing/package/de9c231f84c85def9df09875e1785a1319fa8cb6/lib/libopencv_highgui.a(grfmt_exr.cpp.o): undefined reference to symbol '_ZN4half5_eLutE'
//usr/lib/x86_64-linux-gnu/libHalf.so.6: error adding symbols: DSO missing from command line
```